### PR TITLE
Add support for separate up & down hotkeys

### DIFF
--- a/detector/twokeys/watcher/watch_keyboard.py
+++ b/detector/twokeys/watcher/watch_keyboard.py
@@ -223,6 +223,10 @@ class Keyboard:
         except requests.exceptions.ConnectionError:
             logger.err("Couldn't estanblish a connection to the server.")
             logger.err("Please check your internet connection.")
+        except requests.exceptions.Timeout:
+            logger.err("The request timed out")
+            logger.warn("This means either the server isn't running, or is busy running another hotkey.")
+            logger.warn("Please note the hotkey may still execute after the server has finished running the hotkeys it is currently running")
 
     # Locks (grabs) keyboard
     def lock(self):

--- a/server/src/util/ahk.ts
+++ b/server/src/util/ahk.ts
@@ -35,7 +35,8 @@ export async function fetch_hotkey(keyboard: string, hotkey_code: string): Promi
   const config: Config = await config_loader();
 
   // Get hotkey func
-  let func;
+  let func: string;
+  let type: string;
   if (!config.keyboards.hasOwnProperty(keyboard)) { // Validate
     throw new ReferenceError(`Keyboard ${keyboard} was not found!`);
   } else if (!config.keyboards[keyboard].hotkeys.hasOwnProperty(hotkey_code)) {
@@ -45,16 +46,19 @@ export async function fetch_hotkey(keyboard: string, hotkey_code: string): Promi
   if (typeof hotkey !== "string") {
     // Object type
     func = hotkey.func;
+    type = typeof hotkey.type === "undefined" ? "down" : hotkey.type;
   } else {
     func = hotkey;
+    type = "down";
   }
 
   // Get file
   const file = join(process.cwd(), config.keyboards[keyboard].dir, config.keyboards[keyboard].root);
 
   return {
+    type,
     file,
-    func
+    func,
   }
 }
 

--- a/server/src/util/interfaces.ts
+++ b/server/src/util/interfaces.ts
@@ -127,9 +127,25 @@ export type FileTreeNode = FileTreeDir | FileTreeFile;
 export type FileTreeNodes<T> = T extends FileTreeDir ? FileTreeDir : FileTreeFile;
 
 /**
+ * Hotkey that can be up or down, specifiying how the required functions should be stored
+ */
+export interface HotKeyUpDown {
+  up: string,
+  down: string,
+}
+/**
  * Fetch hotkey interface
  */
 export interface FetchHotkey {
   file: string,
-  func: string
+  func: string | HotKeyUpDown,
+  type: string,
+}
+
+/**
+ * EVDEV value mapping
+ */
+export enum EvDevValues {
+  Up = 0,
+  Down // 1
 }


### PR DESCRIPTION
This adds support for having separate hotkeys for up and down.  The config is as follows:
```yml
SomeKey:
   type: multi # Type key should be able to be safely omitted
   func:
      up: SomeFunc
      down: SomeOtherFunc
```
This is from #21 