### PR TITLE
Update MAPPINGS.md

### DIFF
--- a/docs/MAPPINGS.md
+++ b/docs/MAPPINGS.md
@@ -57,7 +57,7 @@ keyboard:
 | $ENTER$      | Enter                                        |       |
 | $NUMLOCK$    | Numlock                                      |       |
 | $SCROLLLOCK$ | Scrol Lock                                   |       |
-| $NUM1-9$     | Numpad numbers                               |       |
+| NUM1-9       | Numpad numbers                               |       |
 | $NUM_-$      | Numpad negative                              |       |
 | $NUM_+$      | Numpad plus                                  |       |
 | $NUM_.$      | Numpad full stop                             |       |


### PR DESCRIPTION
Mappings for NUM1-9 should not be encased in $ symbols, doing so causes no macro to be fired. Removing these symbols fixes the issue.